### PR TITLE
Make queries accent-insensitive

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,21 +26,21 @@ class User < ApplicationRecord
   scope :search, ->(query) {
     if query.present?
       includes(:projects, :companies)
-        .where("first_name ILIKE ? OR last_name ILIKE ?", "%#{query}%", "%#{query}%")
+        .where("unaccent(first_name) ILIKE unaccent(?) OR unaccent(last_name) ILIKE unaccent(?)", "%#{query}%", "%#{query}%")
     end
   }
 
   scope :assigned_to_project, ->(query) {
     if query.present?
       joins(:projects)
-        .where("projects.name ILIKE ?", "%#{query}%")
+        .where("unaccent(projects.name) ILIKE unaccent(?)", "%#{query}%")
     end
   }
 
   scope :employed_by_company, ->(query) {
     if query.present?
       joins(:companies)
-        .where("companies.name ILIKE ?", "%#{query}%")
+        .where("unaccent(companies.name) ILIKE unaccent(?)", "%#{query}%")
     end
   }
 

--- a/db/migrate/20180430162733_enable_unaccent_extension.rb
+++ b/db/migrate/20180430162733_enable_unaccent_extension.rb
@@ -1,0 +1,5 @@
+class EnableUnaccentExtension < ActiveRecord::Migration[5.2]
+  def change
+    enable_extension 'unaccent'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_03_27_175836) do
+ActiveRecord::Schema.define(version: 2018_04_30_162733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "unaccent"
 
   create_table "activities", force: :cascade do |t|
     t.bigint "user_id"


### PR DESCRIPTION
e.g. query for `"heliport"` finds `"héliport"`.